### PR TITLE
Minor 1.3

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -169,9 +169,15 @@ chrome.tabs.onReplaced.addListener(UpdateTheme);
 
 function SaveCollection()
 {
-	chrome.tabs.query({ currentWindow: true }, function (tabs)
+	chrome.tabs.query({ currentWindow: true }, function (rawTabs)
 	{
-		tabs = tabs.filter(i => !i.url.startsWith("chrome-extension") && !i.url.endsWith("TabsAside.html") && !i.pinned);
+		var tabs = rawTabs.filter(i => !(i.url.startsWith("chrome-extension") && i.url.endsWith("TabsAside.html")) && !i.pinned && !i.url.includes("//newtab"));
+
+		if (tabs.length < 1)
+		{
+			alert("No tabs available to save");
+			return;
+		}
 		
 		var collection =
 		{
@@ -196,8 +202,8 @@ function SaveCollection()
 
 		collections = JSON.parse(localStorage.getItem("sets"));
 
+		chrome.tabs.remove(rawTabs.filter(i => !i.url.startsWith("chrome-extension") && !i.url.endsWith("TabsAside.html") && !i.pinned).map(tab => tab.id));
 		chrome.tabs.create({});
-		chrome.tabs.remove(tabs.map(tab => tab.id));
 	});
 
 	UpdateTheme();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Tabs Aside",
-	"version": "1.2.2",
+	"version": "1.3",
 	"manifest_version": 2,
 	"description": "Classic Microsoft Edge \"Tabs Aside\" feature for Chromium browsers",
 	"author": "Michael \"XFox\" Gordeev",


### PR DESCRIPTION
- Empty tab is now ignored on saving (#8)
- Empty collections cannot be saved now (alert pops up)