### PR TITLE
Added support for restoring tabs discarded

### DIFF
--- a/TabsAside.html
+++ b/TabsAside.html
@@ -31,10 +31,10 @@
 				<button title="Options">&#xE10C;</button>
 
 				<nav>
-					<!-- <p>
+					<p>
 						<input type="checkbox" id="discardOnRestore" oncha/>
 						<label for="discardOnRestore">Load tabs on restore</label>
-					</p> -->
+					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>
 						<button value="https://chrome.google.com/webstore/detail/tabs-aside/mgmjbodjgijnebfgohlnjkegdpbdjgin">Leave feedback</button>

--- a/collections.html
+++ b/collections.html
@@ -6,10 +6,10 @@
 				<button title="Options">&#xE10C;</button>
 	
 				<nav>
-					<!-- <p>
+					<p>
 						<input type="checkbox" id="discardOnRestore"/>
 						<label for="discardOnRestore">Load tabs on restore</label>
-					</p> -->
+					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>
 						<button value="https://chrome.google.com/webstore/detail/tabs-aside/mgmjbodjgijnebfgohlnjkegdpbdjgin">Leave feedback</button>

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -39,7 +39,7 @@ else
 
 					document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
-					/* var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
+					 var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
 					chrome.runtime.sendMessage(
 						{
 							command: "getDiscardOption"
@@ -56,7 +56,7 @@ else
 								command: "toggleDiscard"
 							}
 						);
-					}); */
+					});
 
 					document.querySelectorAll(".tabsAside.pane > header nav button").forEach(i => 
 					{
@@ -120,7 +120,7 @@ function InitializeStandalone()
 
 	document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
-	/* var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
+	var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
 	chrome.runtime.sendMessage(
 		{
 			command: "getDiscardOption"
@@ -137,7 +137,7 @@ function InitializeStandalone()
 				command: "toggleDiscard"
 			}
 		);
-	}); */
+	});
 
 	document.querySelectorAll(".tabsAside.pane > header nav button").forEach(i => 
 	{

--- a/js/background.js
+++ b/js/background.js
@@ -236,20 +236,19 @@ function RestoreCollection(collectionIndex, removeCollection)
 			{
 				url: i,
 				active: false
-			}/* , function (tab)
+			} , function (createdTab)
 		{
-			if (localStorage.getItem("loadOnRestore") == "false" ? true : false)
-			{
-				setTimeout(function()
-				{
-					chrome.tabs.get(tab.id, function(tab1)
-					{
-						console.log(tab.url);
-						chrome.tabs.discard(tab1.id);
-					});
-				}, 1000);
+			if (localStorage.getItem("loadOnRestore") == "false" ? true : false) {
+				chrome.tabs.onUpdated.addListener(function discarder(updatedTabId, changeInfo, updatedTab) {
+					if (updatedTabId === createdTab.id) {
+						chrome.tabs.onUpdated.removeListener(discarder);
+						if (!updatedTab.active) {
+							chrome.tabs.discard(updatedTabId);
+						}
+					}
+				});
 			}
-		} */);
+		});
 	});
 
 	if (!removeCollection)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Tabs Aside",
-	"version": "1.3.1",
+	"version": "1.4",
 	"manifest_version": 2,
 	"description": "Classic Microsoft Edge \"Tabs Aside\" feature for Chromium browsers",
 	"author": "Michael \"XFox\" Gordeev",


### PR DESCRIPTION
Opening as draft, as I still have to figure out a few things !

This fixes #10 
- [x] Tabs should be opened and discarded before they load, if the "loadOnRestore" setting is disabled.
- [x] The active tab does not get discarded.
I may have made a mistake with that one - I did not finish my exploration of this repo, but I'm yet to find any scenario where a tab gets restored as the active one. I thought restoring from the TabsAside.html tab would remove it and make one of the restored ones active, but it appears not.

Misc :

- [x] The "loadOnRestore" setting should be togglable by the user
