### PR TITLE
Background optimizations & fixes

### DIFF
--- a/TabsAside.html
+++ b/TabsAside.html
@@ -32,8 +32,8 @@
 
 				<nav>
 					<p>
-						<input type="checkbox" id="discardOnRestore" oncha/>
-						<label for="discardOnRestore">Load tabs on restore</label>
+						<input type="checkbox" id="loadOnRestore" oncha/>
+						<label for="loadOnRestore">Load tabs on restore</label>
 					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>

--- a/TabsAside.html
+++ b/TabsAside.html
@@ -32,11 +32,12 @@
 
 				<nav>
 					<p>
-						<input type="checkbox" id="loadOnRestore" oncha/>
+						<input type="checkbox" id="loadOnRestore"/>
 						<label for="loadOnRestore">Load tabs on restore</label>
 					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>
+						<button value="https://github.com/XFox111/ChromiumTabsAside/graphs/contributors">Project contributors</button>
 						<button value="https://chrome.google.com/webstore/detail/tabs-aside/mgmjbodjgijnebfgohlnjkegdpbdjgin">Leave feedback</button>
 						<button value="https://buymeacoffee.com/xfox111">Buy me a coffee!</button>
 						<!-- <button hidden>Backup saved tabs</button> -->

--- a/collections.html
+++ b/collections.html
@@ -12,6 +12,7 @@
 					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>
+						<button value="https://github.com/XFox111/ChromiumTabsAside/graphs/contributors">Project contributors</button>
 						<button value="https://chrome.google.com/webstore/detail/tabs-aside/mgmjbodjgijnebfgohlnjkegdpbdjgin">Leave feedback</button>
 						<button value="https://buymeacoffee.com/xfox111">Buy me a coffee!</button>
 						<!--<button hidden>Backup saved tabs</button>-->

--- a/collections.html
+++ b/collections.html
@@ -7,8 +7,8 @@
 	
 				<nav>
 					<p>
-						<input type="checkbox" id="discardOnRestore"/>
-						<label for="discardOnRestore">Load tabs on restore</label>
+						<input type="checkbox" id="loadOnRestore"/>
+						<label for="loadOnRestore">Load tabs on restore</label>
 					</p>
 					<div>
 						<button value="https://github.com/xfox111/ChromiumTabsAside">Visit GitHub page</button>

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -43,6 +43,15 @@ else
 					chrome.storage.sync.get({ "loadOnRestore": false },
 						values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 					);
+					chrome.storage.onChanged.addListener(function (changes, namespace) {
+						if (namespace == 'sync'){
+							for (key in changes) {
+								if (key === 'loadOnRestore') {
+									loadOnRestoreCheckbox.checked = changes[key].newValue
+								}
+							}
+						}
+					});
 					loadOnRestoreCheckbox.addEventListener("click", function ()
 					{
 						chrome.storage.sync.set(
@@ -117,6 +126,15 @@ function InitializeStandalone()
 	chrome.storage.sync.get({ "loadOnRestore": false },
 		values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 	);
+	chrome.storage.onChanged.addListener(function (changes, namespace) {
+		if (namespace == 'sync'){
+			for (key in changes) {
+				if (key === 'loadOnRestore') {
+					loadOnRestoreCheckbox.checked = changes[key].newValue
+				}
+			}
+		}
+	});
 	loadOnRestoreCheckbox.addEventListener("click", function ()
 	{
 		chrome.storage.sync.set(

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -40,18 +40,15 @@ else
 					document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
 					var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
-					chrome.storage.sync.get({ "loadOnRestore" : false },
+					chrome.storage.sync.get({ "loadOnRestore": false },
 						values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 					);
 					loadOnRestoreCheckbox.addEventListener("click", function ()
 					{
-						chrome.storage.sync.get({ "loadOnRestore" : false },
-							values => chrome.storage.sync.set(
-								{
-									"loadOnRestore": !values.loadOnRestore
-								}
-							)
-						);
+						chrome.storage.sync.set(
+							{
+								"loadOnRestore": loadOnRestoreCheckbox.checked
+							});
 					});
 
 					document.querySelectorAll(".tabsAside.pane > header nav button").forEach(i => 
@@ -117,18 +114,15 @@ function InitializeStandalone()
 	document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
 	var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
-	chrome.storage.sync.get({ "loadOnRestore" : false },
+	chrome.storage.sync.get({ "loadOnRestore": false },
 		values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 	);
 	loadOnRestoreCheckbox.addEventListener("click", function ()
 	{
-		chrome.storage.sync.get({ "loadOnRestore" : false },
-			values => chrome.storage.sync.set(
-				{
-					"loadOnRestore": !values.loadOnRestore
-				}
-			)
-		);
+		chrome.storage.sync.set(
+			{
+				"loadOnRestore": loadOnRestoreCheckbox.checked
+			});
 	});
 
 	document.querySelectorAll(".tabsAside.pane > header nav button").forEach(i => 

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -39,7 +39,7 @@ else
 
 					document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
-					 var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
+					var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
 					chrome.storage.sync.get({ "loadOnRestore" : false },
 						values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 					);

--- a/js/aside-script.js
+++ b/js/aside-script.js
@@ -40,21 +40,17 @@ else
 					document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
 					 var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
-					chrome.runtime.sendMessage(
-						{
-							command: "getDiscardOption"
-						},
-						function(loadOnRestore)
-						{
-							loadOnRestoreCheckbox.checked = loadOnRestore;
-						}
+					chrome.storage.sync.get({ "loadOnRestore" : false },
+						values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 					);
 					loadOnRestoreCheckbox.addEventListener("click", function ()
 					{
-						chrome.runtime.sendMessage(
-							{
-								command: "toggleDiscard"
-							}
+						chrome.storage.sync.get({ "loadOnRestore" : false },
+							values => chrome.storage.sync.set(
+								{
+									"loadOnRestore": !values.loadOnRestore
+								}
+							)
 						);
 					});
 
@@ -121,21 +117,17 @@ function InitializeStandalone()
 	document.querySelector("nav > p > small").textContent = chrome.runtime.getManifest()["version"];
 
 	var loadOnRestoreCheckbox = document.querySelector("nav > p > input[type=checkbox]");
-	chrome.runtime.sendMessage(
-		{
-			command: "getDiscardOption"
-		},
-		function(loadOnRestore)
-		{
-			loadOnRestoreCheckbox.checked = loadOnRestore;
-		}
+	chrome.storage.sync.get({ "loadOnRestore" : false },
+		values => loadOnRestoreCheckbox.checked = values.loadOnRestore
 	);
 	loadOnRestoreCheckbox.addEventListener("click", function ()
 	{
-		chrome.runtime.sendMessage(
-			{
-				command: "toggleDiscard"
-			}
+		chrome.storage.sync.get({ "loadOnRestore" : false },
+			values => chrome.storage.sync.set(
+				{
+					"loadOnRestore": !values.loadOnRestore
+				}
+			)
 		);
 	});
 

--- a/js/background.js
+++ b/js/background.js
@@ -212,9 +212,9 @@ function SaveCollection()
 		chrome.tabs.create({}, function(tab) { newTabId = tab.id; });
 		
 		chrome.tabs.remove(rawTabs.filter(i => !i.url.startsWith("chrome-extension") && !i.url.endsWith("TabsAside.html") && !i.pinned && i.id != newTabId).map(tab => tab.id));
-	});
 
 	UpdateTheme();
+});
 }
 
 function DeleteCollection(collectionIndex)

--- a/js/background.js
+++ b/js/background.js
@@ -204,8 +204,8 @@ function SaveCollection()
 		
 		chrome.tabs.remove(rawTabs.filter(i => !i.url.startsWith("chrome-extension") && !i.url.endsWith("TabsAside.html") && !i.pinned && i.id != newTabId).map(tab => tab.id));
 
-	UpdateTheme();
-});
+		UpdateTheme();
+	});
 }
 
 function DeleteCollection(collectionIndex)

--- a/js/background.js
+++ b/js/background.js
@@ -143,15 +143,6 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse)
 		case "share":
 			ShareTabs(message.collectionIndex);
 			break;
-		case "toggleDiscard":
-			if (localStorage.getItem("loadOnRestore") == "true")
-				localStorage.setItem("loadOnRestore", false);
-			else
-				localStorage.setItem("loadOnRestore", true);
-			break;
-		case "getDiscardOption":
-			sendResponse(localStorage.getItem("loadOnRestore") == "false");
-			break;
 	}
 });
 
@@ -235,16 +226,17 @@ function RestoreCollection(collectionIndex, removeCollection)
 				active: false
 			} , function (createdTab)
 		{
-			if (localStorage.getItem("loadOnRestore") == "false") {
-				chrome.tabs.onUpdated.addListener(function discarder(updatedTabId, changeInfo, updatedTab) {
-					if (updatedTabId === createdTab.id) {
-						chrome.tabs.onUpdated.removeListener(discarder);
-						if (!updatedTab.active) {
-							chrome.tabs.discard(updatedTabId);
+			chrome.storage.sync.get({ "loadOnRestore" : false }, values => {
+				if (!values.loadOnRestore)
+					chrome.tabs.onUpdated.addListener(function discarder(updatedTabId, changeInfo, updatedTab) {
+						if (updatedTabId === createdTab.id) {
+							chrome.tabs.onUpdated.removeListener(discarder);
+							if (!updatedTab.active) {
+								chrome.tabs.discard(updatedTabId);
+							}
 						}
-					}
-				});
-			}
+					});
+			});
 		});
 	});
 

--- a/js/background.js
+++ b/js/background.js
@@ -147,8 +147,6 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse)
 });
 
 UpdateTheme();
-chrome.windows.onCreated.addListener(UpdateTheme);
-chrome.windows.onRemoved.addListener(UpdateTheme);
 chrome.windows.onFocusChanged.addListener(UpdateTheme);
 
 chrome.tabs.onUpdated.addListener(UpdateTheme);

--- a/js/background.js
+++ b/js/background.js
@@ -37,25 +37,22 @@ chrome.browserAction.onClicked.addListener(function (tab)
 		chrome.tabs.create({
 			url: chrome.extension.getURL("TabsAside.html"),
 			active: true
-		});
+		},
+			chrome.tabs.onActivated.addListener(function TabsAsideCloser(activeInfo) {
+				chrome.tabs.query({ url: chrome.extension.getURL("TabsAside.html") }, function (result) {
+					if (result.length)
+						setTimeout(function () {
+							result.forEach(i => {
+								if (activeInfo.tabId != i.id)
+									chrome.tabs.remove(i.id);
+							});
+						}, 200);
+					else chrome.tabs.onActivated.removeListener(TabsAsideCloser);
+				});
+			}));
 	}
 });
 
-chrome.tabs.onActivated.addListener(function (activeInfo)
-{
-	chrome.tabs.query({ url: chrome.extension.getURL("TabsAside.html") }, function (result)
-	{
-		if (result.length)
-			setTimeout(function ()
-			{
-				result.forEach(i => 
-				{
-					if (activeInfo.tabId != i.id)
-						chrome.tabs.remove(i.id);
-				});
-			}, 200);
-	});
-});
 
 function UpdateTheme()
 {

--- a/js/background.js
+++ b/js/background.js
@@ -152,17 +152,7 @@ chrome.windows.onRemoved.addListener(UpdateTheme);
 chrome.windows.onFocusChanged.addListener(UpdateTheme);
 
 chrome.tabs.onUpdated.addListener(UpdateTheme);
-chrome.tabs.onCreated.addListener(UpdateTheme);
-chrome.tabs.onMoved.addListener(UpdateTheme);
-chrome.tabs.onSelectionChanged.addListener(UpdateTheme);
-chrome.tabs.onActiveChanged.addListener(UpdateTheme);
 chrome.tabs.onActivated.addListener(UpdateTheme);
-chrome.tabs.onHighlightChanged.addListener(UpdateTheme);
-chrome.tabs.onHighlighted.addListener(UpdateTheme);
-chrome.tabs.onDetached.addListener(UpdateTheme);
-chrome.tabs.onAttached.addListener(UpdateTheme);
-chrome.tabs.onRemoved.addListener(UpdateTheme);
-chrome.tabs.onReplaced.addListener(UpdateTheme);
 
 function SaveCollection()
 {

--- a/js/background.js
+++ b/js/background.js
@@ -150,7 +150,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse)
 				localStorage.setItem("loadOnRestore", true);
 			break;
 		case "getDiscardOption":
-			sendResponse(localStorage.getItem("loadOnRestore") == "false" ? false : true);
+			sendResponse(localStorage.getItem("loadOnRestore") == "false");
 			break;
 	}
 });

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,7 @@
 	[
 		"tabs",
 		"unlimitedStorage",
+		"storage",
 		"<all_urls>"
 	],
 	

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,6 @@
 	"background":
 	{
 		"scripts": [ "js/background.js" ],
-		"persistent": true
+		"persistent": false
 	}
 }


### PR DESCRIPTION
Here are two useful links regarding [background pages](https://developer.chrome.com/extensions/background_pages) and [migration to non-persistent background scripts](https://developer.chrome.com/extensions/background_migration)

Activation & Listeners
- [x] Made background scripts non-persistent
This means chrome will dynamically unload the script when unused, and load it back on events. I'm afraid it still does not happen quite often, due to the frequent tab update/activation event listeners.
- [x] Made the listener that closes the TabsAside page remove itself when not needed, and add itself when needed
- [x] Removed redundant and deprecated listeners for the UpdateTheme function.

Settings & Messages
- [x] Reduced the amount of messages to the background script by switching the settings to [chrome.storage](https://developer.chrome.com/extensions/storage).sync instead of localStorage

Misc
- [x] Renamed the checkbox's id for the "loadOnRestore" setting.

- [ ] Bump version, due to a manifest update